### PR TITLE
Added a sendJSON method to the HttpTransport class

### DIFF
--- a/http_transport.go
+++ b/http_transport.go
@@ -30,7 +30,11 @@ func (self HttpTransport) connectionType() string {
 
 func (self HttpTransport) send(data map[string]interface{}) (Response, error) {
 	dataBytes, _ := json.Marshal(data)
-	buffer := bytes.NewBuffer(dataBytes)
+	return self.sendJSON(dataBytes)
+}
+
+func (self HttpTransport) sendJSON(json string) (Response, error) {
+	buffer := bytes.NewBuffer(json)
 	responseData, err := http.Post(self.url, "application/json", buffer)
 	if err != nil {
 		return Response{}, err
@@ -43,7 +47,7 @@ func (self HttpTransport) send(data map[string]interface{}) (Response, error) {
 	var jsonData []interface{}
 	json.Unmarshal(readData, &jsonData)
 	response := newResponse(jsonData)
-	return response, nil
+	return response, nil	
 }
 
 func (self *HttpTransport) setUrl(url string) {


### PR DESCRIPTION
For the cases where you have a `struct` with custom JSON field names already setup.  

Instead of converting that to a map, you can just marshal it yourself and give the raw string to `sendJSON`.  To keep it DRY I simply copied the bulk of the `send` method into the `sendJSON` method, and then called `sendJSON` from the `send` method.
