### PR TITLE
Made Listen do a handshake if not already connected

### DIFF
--- a/go_faye.go
+++ b/go_faye.go
@@ -122,6 +122,9 @@ func (self *FayeClient) listen(responseChannel chan Response) {
 }
 
 func (self *FayeClient) Listen() {
+	if self.state != CONNECTED {
+		self.handshake()
+	}
 	for {
 		self.connect()
 	}


### PR DESCRIPTION
This can cause a nil pointer error if you call Listen() before you called a method that does a handshake.  So now it is conducive to doing `go faye.Listen()` and putting your typical calls under that:

``` go
go faye.Listen()

faye.Subscribe("/things", handleMessage)
faye.Subscribe("/stuff", handleMessage)

faye.Publish("/stuff", data)
faye.Publish("/things", data)
```

Personally I wrap wray with a Facade and do `go faye.Listen()` in the New() function so the Facade can then be returned as the following interface, abstracting away the client/backend details:

``` go
type IPubsub interface {
  Subscribe(string, func(msg Message))
  Publish(string, map[string]interface{})
}
```
