### PR TITLE
Subscription failure handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,17 +33,17 @@ func main() {
   })
 
   if err != nil {
-    fmt.Println("Subscription to /foo failed")
+    fmt.Println("Subscription to /foo failed", err)
   }
 
   //wildcards can be used to subscribe to multipule channels
-  _, err = client.Subscribe("/foo/*", false, func(message wray.Message) {
+  promise, _ = client.Subscribe("/foo/*", false, func(message wray.Message) {
     fmt.Println("-------------------------------------------")
     fmt.Println(message.Data)
   })
 
-  if err != nil {
-    fmt.Println("Subscription to /foo/* failed")
+  if !promise.Successful() {
+    fmt.Println("Subscription to /foo/* failed", promise.Error())
   }
 
   // try to subscribe forever

--- a/README.markdown
+++ b/README.markdown
@@ -12,11 +12,12 @@ Wray is only a client for Faye. You will need to setup a server using Ruby or No
 
 ###Subscribing to channels
 
-```
+```go
 package main
 
 import "github.com/pythonandchips/wray"
 import "fmt"
+import "time"
 
 func main() {
   //register the types of transport you want available. Only long-polling is currently supported
@@ -26,16 +27,38 @@ func main() {
   client := wray.NewFayeClient("http://localhost:5000/faye")
 
   //subscribe to the channels you want to listen to
-  client.Subscribe("/foo", false, func(message wray.Message) {
+  _, err := client.Subscribe("/foo", false, func(message wray.Message) {
     fmt.Println("-------------------------------------------")
     fmt.Println(message.Data)
   })
 
+  if err != nil {
+    fmt.Println("Subscription to /foo failed")
+  }
+
   //wildcards can be used to subscribe to multipule channels
-  client.Subscribe("/foo/*", false, func(message wray.Message) {
+  _, err = client.Subscribe("/foo/*", false, func(message wray.Message) {
     fmt.Println("-------------------------------------------")
     fmt.Println(message.Data)
   })
+
+  if err != nil {
+    fmt.Println("Subscription to /foo/* failed")
+  }
+
+  // try to subscribe forever
+  for {
+    _, err = client.Subscribe("/foo/*", false, func(message wray.Message) {
+      fmt.Println("-------------------------------------------")
+      fmt.Println(message.Data)
+    })
+
+    if err == nil {
+      break // break out of the loop if there was no error
+    }
+
+    time.Sleep(1*time.Second)
+  }
 
   //start listening on all subscribed channels and hold the process open
   client.Listen()
@@ -43,7 +66,8 @@ func main() {
 ```
 
 ###Publishing to channels
-```
+
+```go
 package main
 
 import "github.com/pythonandchips/wray"

--- a/go_faye.go
+++ b/go_faye.go
@@ -1,6 +1,7 @@
 package wray
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -80,16 +81,28 @@ func (self *FayeClient) handshake() {
 	}
 }
 
-func (self *FayeClient) Subscribe(channel string, force bool, callback func(Message)) SubscriptionPromise {
+func (self *FayeClient) Subscribe(channel string, force bool, callback func(Message)) (promise SubscriptionPromise, err error) {
 	if self.state == UNCONNECTED {
 		self.handshake()
 	}
 	subscriptionParams := map[string]interface{}{"channel": "/meta/subscribe", "clientId": self.clientId, "subscription": channel, "id": "1"}
 	subscription := Subscription{channel: channel, callback: callback}
-	//TODO: deal with subscription failures
-	self.transport.send(subscriptionParams)
+
+	res, err := self.transport.send(subscriptionParams)
+
+	if err != nil {
+		return
+	}
+
+	if !res.successful {
+		// TODO: put more information in the error message about why it failed
+		err = errors.New("Response was unsuccessful")
+		return
+	}
+
+	promise = SubscriptionPromise{subscription}
 	self.subscriptions = append(self.subscriptions, subscription)
-	return SubscriptionPromise{subscription}
+	return
 }
 
 func (self *FayeClient) handleResponse(response Response) {

--- a/go_faye_test.go
+++ b/go_faye_test.go
@@ -43,6 +43,7 @@ func TestSubscribe(t *testing.T) {
 		var fakeHttpTransport *FakeHttpTransport
 		var subscriptionParams map[string]interface{}
 		var response Response
+		var err error
 		Given(func() {
 			response = Response{id: "1", channel: "/meta/handshake", successful: true, clientId: "client4", supportedConnectionTypes: []string{"long-polling"}}
 		})
@@ -53,8 +54,9 @@ func TestSubscribe(t *testing.T) {
 			subscriptionParams = map[string]interface{}{"channel": "/meta/subscribe", "clientId": response.clientId, "subscription": "/foo/*", "id": "1"}
 		})
 		Given(func() { callback = func(message Message) {} })
-		When(func() { subscriptionPromise = fayeClient.Subscribe("/foo/*", false, callback) })
+		When(func() { subscriptionPromise, err = fayeClient.Subscribe("/foo/*", false, callback) })
 		Convey("connects the faye client", func() {
+			Then(func() { So(err, ShouldEqual, nil) })
 			Then(func() { So(fayeClient.state, ShouldEqual, CONNECTED) })
 		})
 		Convey("add the subscription to the client", func() {

--- a/response.go
+++ b/response.go
@@ -1,61 +1,75 @@
 package wray
 
 type Response struct {
-  id string
-  channel string
-  successful bool
-  clientId string
+  id                       string
+  channel                  string
+  successful               bool
+  clientId                 string
   supportedConnectionTypes []string
-  messages []Message
-  error error
+  messages                 []Message
+  error                    error
 }
 
 type Message struct {
   Channel string
-  Id string
-  Data map[string]interface{}
+  Id      string
+  Data    map[string]interface{}
 }
 
 func newResponse(data []interface{}) Response {
   headerData := data[0].(map[string]interface{})
   messagesData := data[1.:]
   messages := parseMessages(messagesData)
+
   var id string
   if headerData["id"] != nil {
     id = headerData["id"].(string)
   }
+
   supportedConnectionTypes := []string{}
+
   if headerData["supportedConnectionTypes"] != nil {
     d := headerData["supportedConnectionTypes"].([]interface{})
-    for _, sct := range(d) {
+    for _, sct := range d {
       supportedConnectionTypes = append(supportedConnectionTypes, sct.(string))
     }
   }
+
   var clientId string
   if headerData["clientId"] != nil {
     clientId = headerData["clientId"].(string)
   }
-  return Response{id: id,
-                  clientId: clientId,
-                  channel: headerData["channel"].(string),
-                  successful: headerData["successful"].(bool),
-                  messages: messages,
-                  supportedConnectionTypes: supportedConnectionTypes}
+
+  return Response{
+    id:                       id,
+    clientId:                 clientId,
+    channel:                  headerData["channel"].(string),
+    successful:               headerData["successful"].(bool),
+    messages:                 messages,
+    supportedConnectionTypes: supportedConnectionTypes,
+  }
 }
 
 func parseMessages(data []interface{}) []Message {
   messages := []Message{}
-  for _, messageData := range(data) {
+
+  for _, messageData := range data {
+
     m := messageData.(map[string]interface{})
     var id string
+
     if m["id"] != nil {
       id = m["id"].(string)
     }
-    message := Message{Channel: m["channel"].(string),
-                       Id: id,
-                       Data: m["data"].(map[string]interface{})}
+
+    message := Message{
+      Channel: m["channel"].(string),
+      Id:      id,
+      Data:    m["data"].(map[string]interface{}),
+    }
+
     messages = append(messages, message)
   }
+
   return messages
 }
-


### PR DESCRIPTION
OK, made this thing handle subscription failures, even added a test for it :+1: (first time working with GoConvey).

Here's the skinny:

``` go
// standard go way
_, err := client.Subscribe("/foo", false, func(message wray.Message) {
  fmt.Println("-------------------------------------------")
  fmt.Println(message.Data)
})

if err != nil {
  fmt.Println("Subscription to /foo failed", err)
}

// USE THE PROMISE, LUKE!
promise, _ = client.Subscribe("/foo/*", false, func(message wray.Message) {
  fmt.Println("-------------------------------------------")
  fmt.Println(message.Data)
})

if !promise.Successful() {
  fmt.Println("Subscription to /foo/* failed", promise.Error())
}
```

I wasn't sure whether to skip the returning of the error as the second param, but it is a go idiom... so I thought I would leave it there.  What say you @pythonandchips ?
